### PR TITLE
Switch to envelope encryption with KMS data key and AES for the contents

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ COPY requirements.txt /opt/app
 RUN pip3 install --no-cache-dir -r /opt/app/requirements.txt
 
 COPY server.py /opt/app
+COPY encrypt.py /opt/app
 
 ENV FLASK_APP=/opt/app/server.py
 EXPOSE 8001

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Read the full guide to using this app at https://edgebit.com/enclaver/docs/0.x/guide-app/
 
+The info below is just for building and testing the demo app.
+
 ## Container Images
 
 TODO: build and publish these publicly
@@ -16,27 +18,27 @@ docker build -t demo-enclave -f Dockerfile . && docker run --name enclave -d -p 
 
 This is only for EdgeBit staff, who have access to update the encrypted No-Fly-List contained in the demo container.
 
-First, configure your AWS credentials via environment variables:
+1. Configure your AWS credentials via environment variables:
 
 ```
-export AWS_ACCESS_KEY_ID=
-export AWS_SECRET_ACCESS_KEY=
+$ export AWS_ACCESS_KEY_ID=
+$ export AWS_SECRET_ACCESS_KEY=
 ```
 
-Populate your new list at no-fly.txt:
+2. Populate your new list:
 
 ```
 fullname,anothername
 ```
 
-Now you can curl in a new list which will be encrypted with the KMS key and returned to you:
+3. Start the container but overrride the `FLASK_APP`:
 
 ```
-aws kms encrypt --key-id mrk-b3152356da604a7dac485a0a272957c7 --plaintext "$(cat no-fly.txt | base64)" --query CiphertextBlob --output text > no-fly-encrypted.txt
+docker build -t demo-enclave -f Dockerfile . && docker run --name enclave -d -p 8001:8001 -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION=us-east-1 -e PYTHONUNBUFFERED=1 -e FLASK_APP=/opt/app/encrypt.py --rm demo-enclave 
 ```
 
-Then upload those contents to S3:
+3. Curl it to encrypt and uplaod it to S3:
 
 ```
-aws s3 cp no-fly-encrypted.txt s3://no-fly-list/
+curl -d "list=fullname,anothername" -X POST http://localhost:8001/enclave/encrypt
 ```

--- a/encrypt.py
+++ b/encrypt.py
@@ -1,0 +1,63 @@
+import os
+import json
+from flask import Flask
+from flask import render_template
+from flask import request
+from flask import jsonify
+import base64
+import boto3
+from cryptography.fernet import Fernet
+
+app = Flask(__name__)
+
+def push_S3(envelope):
+
+  s3 = boto3.resource('s3')
+  object = s3.Object('no-fly-list', 'no-fly-envelope.txt')
+
+  object.put(
+      Body=(bytes(json.dumps(envelope).encode('UTF-8')))
+  )
+
+def encrypt_envelope(list):
+
+  # Get a KMS client
+  client = boto3.client("kms")
+
+  # Generate a new data key
+  response = client.generate_data_key(KeyId="mrk-b3152356da604a7dac485a0a272957c7", KeySpec="AES_256")
+
+  # The response includes both plaintext and encrypted versions of the data key
+  plain_data_key = base64.b64encode(response["Plaintext"])
+  encrypted_data_key = base64.b64encode(response["CiphertextBlob"])
+
+  # Use the plaintext key to encrypt our data, and then throw it away
+  f = Fernet(plain_data_key)
+  crypted = f.encrypt(bytes(list, 'utf-8'))
+
+  envelope = {}
+  envelope["data-key-ciphertext-base64"] = encrypted_data_key.decode()
+  envelope["aes-ciphertext-base64"] = crypted.decode()
+
+  return envelope
+
+@app.route('/')
+def index():
+  return jsonify("https://edgebit.com/enclaver/docs/0.x/guide-app/")
+
+@app.route('/enclave/encrypt', methods=['POST'])
+def encrypt():  
+
+  # Read the list
+  plaintext_list = request.form["list"]
+
+  # Encrypt an envelope
+  encrypted_envelope = encrypt_envelope(plaintext_list)
+
+  # Upload it to S3
+  push_S3(encrypted_envelope)
+
+  return encrypted_envelope
+
+if __name__ == '__main__':
+    app.run(port=os.getenv('PORT', 8000))

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ python-dotenv==0.14.0
 twilio~=6.0.0
 boto3==1.4.8
 botocore==1.8.1
+cryptography==38.0.1


### PR DESCRIPTION
This switches the app to use envelope encryption instead of directly using KMS. Using envelope in encryption is more correct for larger content data sizes, although that doesn't come into play here.

This also adds an encrypt endpoint when run locally to set up the S3/server side parts of the demo.