### PR TITLE
Push both enclave-latest and enclave+SHA tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,5 +55,5 @@ jobs:
           ./enclaver build -f enclaver.yaml
           docker tag no-fly-list:enclave-latest us-docker.pkg.dev/edgebit-containers/containers/no-fly-list:enclave-${{ env.SHORT_SHA }}
           docker tag no-fly-list:enclave-latest us-docker.pkg.dev/edgebit-containers/containers/no-fly-list:enclave-latest
-          docker images
           docker push us-docker.pkg.dev/edgebit-containers/containers/no-fly-list:enclave-latest
+          docker push us-docker.pkg.dev/edgebit-containers/containers/no-fly-list:enclave-${{ env.SHORT_SHA }}


### PR DESCRIPTION
I assumed that it would push all tags that matched the given container image SHA, but I was wrong. This manually pushes both.