### PR TITLE
Use enclave's KMS proxy

### DIFF
--- a/enclaver.yaml
+++ b/enclaver.yaml
@@ -5,9 +5,12 @@ sources:
   app: "us-docker.pkg.dev/edgebit-containers/containers/no-fly-list:latest"
 defaults:
   memory_mb: 4096
+kms_proxy:
+  listen_port: 9999
 egress:
   allow:
     - kms.*.amazonaws.com
     - no-fly-list.s3.us-east-1.amazonaws.com
+    - 169.254.169.254
 ingress:
   - listen_port: 8001

--- a/server.py
+++ b/server.py
@@ -13,7 +13,11 @@ app = Flask(__name__)
 def decrypt_envelope(envelope):
 
   # Get a KMS client
-  client = boto3.client("kms")
+  # Check if the enclave's KMS proxy is configured
+  if(os.environ.get('AWS_KMS_ENDPOINT')):
+    client = boto3.client("kms", endpoint_url=os.environ.get('AWS_KMS_ENDPOINT'))
+  else:
+     client = boto3.client("kms");
 
   # Decrypt the data key from the data_key column
   decrypted_key = client.decrypt(CiphertextBlob=base64.b64decode(envelope["data-key-ciphertext-base64"]))


### PR DESCRIPTION
1. Adds the metadata service url to the allowed egress endpoints
2. Configures the KMS proxy to listen on 9999 and reads the ENV VAR in the app if it's set