### PR TITLE
Use less specific S3 hostname

### DIFF
--- a/enclaver.yaml
+++ b/enclaver.yaml
@@ -10,7 +10,7 @@ kms_proxy:
 egress:
   allow:
     - kms.*.amazonaws.com
-    - no-fly-list.s3.us-east-1.amazonaws.com
+    - s3.us-east-1.amazonaws.com
     - 169.254.169.254
 ingress:
   - listen_port: 8001


### PR DESCRIPTION
I don't think the boto library constructs requests in a manner that would use the previous hostname